### PR TITLE
Install pip2 and pip3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get -y install \
   pkg-config \
   python \
   python3 \
+  python-pip \
+  python3-pip \
   sqlite3 \
   vim \
   wget \


### PR DESCRIPTION
I have a student that needs to install `requests` and `argparse` in the docker image. This requires `pip` to be installed. The student tried these approaches with the existing docker image and they all failed:

``` bash
    python -m pip install requests
    > /usr/bin/python: No module named pip

    easy_install pip
    > /bin/bash: line 58: easy_install: command not found
    > ERROR: Job failed: exit code 1

    pip install requests
    > /bin/bash: line 58: pip: command not found
```